### PR TITLE
Issue60 check free parameters

### DIFF
--- a/mpcpy/models.py
+++ b/mpcpy/models.py
@@ -194,9 +194,22 @@ class Modelica(_Model, utility._FMU, utility._Building):
 
         '''
         
-        self._set_time_interval(start_time, final_time);        
-        self.measurement_variable_list = measurement_variable_list;
-        self._estimate_method._estimate(self);
+        # Check for free parameters
+        free = False;
+        for key in self.parameter_data.keys():
+            if self.parameter_data[key]['Free'].get_base_data():
+                free = True;
+                break
+            else:
+                free = False;
+        if not free:
+            # If none free raise error
+            raise ValueError('No parameters set as "Free" in parameter_data dictionary. Cannot run parameter estimation.');
+        else:
+            # Otherwise, continue with parameter estimation
+            self._set_time_interval(start_time, final_time);
+            self.measurement_variable_list = measurement_variable_list;
+            self._estimate_method._estimate(self);
         
     def validate(self, start_time, final_time, validate_filename, plot = 1):
         '''Validate the estimated parameters of the model.

--- a/unittests/test_models.py
+++ b/unittests/test_models.py
@@ -72,6 +72,36 @@ class SimpleRC(TestCaseMPCPy):
         # Check references
         df_test = self.model.display_measurements('Simulated');
         self.check_df_timeseries(df_test, 'simulate_noinputs.csv');
+        
+    def test_estimate_error_nofreeparameters(self):
+        '''Test error raised if no free parameters passed.'''
+        # Set model paths
+        mopath = os.path.join(self.MPCPyPath, 'resources', 'model', 'Simple.mo');
+        modelpath = 'Simple.RC_noinputs';
+        # Instantiate model
+        self.model_no_params = models.Modelica(models.JModelica, \
+                                               models.RMSE, \
+                                               self.measurements, \
+                                               moinfo = (mopath, modelpath, {}));
+        # Check error raised with no parameters
+        with self.assertRaises(ValueError):
+            self.model_no_params.estimate(self.start_time, self.final_time, []);
+        # Set parameters
+        parameter_data = {};
+        parameter_data['C'] = {};
+        parameter_data['C']['Value'] = variables.Static('C_Value', 55000, units.J_K);
+        parameter_data['C']['Minimum'] = variables.Static('C_Min', 10000, units.J_K);
+        parameter_data['C']['Maximum'] = variables.Static('C_Max', 100000, units.J_K);
+        parameter_data['C']['Free'] = variables.Static('C_Free', False, units.boolean);
+        # Instantiate model
+        self.model_no_free = models.Modelica(models.JModelica, \
+                                               models.RMSE, \
+                                               self.measurements, \
+                                               moinfo = (mopath, modelpath, {}), \
+                                               parameter_data = parameter_data);
+        # Check error raised with no free parameters
+        with self.assertRaises(ValueError):
+            self.model_no_params.estimate(self.start_time, self.final_time, []);
 
 #%%    
 class EstimateFromJModelica(TestCaseMPCPy):


### PR DESCRIPTION
Fixed by checking for free parameters before running parameter estimation.  ValueError is thrown if conditions not met.